### PR TITLE
[FIX] XSS validating context and encoding HTML

### DIFF
--- a/src/jquery.form.js
+++ b/src/jquery.form.js
@@ -262,6 +262,10 @@
 				var successArguments = arguments,
 					fn = options.replaceTarget ? 'replaceWith' : 'html';
 
+					// Validate `data` through `HTML encoding` when passed `data` is passed 
+					// to `html()`, as suggested in https://github.com/jquery-form/form/issues/464
+					fn == 'html' ? data = $.parseHTML($("<div>").text(data).html()) : '';
+
 				$(options.target)[fn](data).each(function(){
 					oldSuccess.apply(this, successArguments);
 				});
@@ -923,8 +927,12 @@
 				return (doc && doc.documentElement && doc.documentElement.nodeName !== 'parsererror') ? doc : null;
 			};
 			var parseJSON = $.parseJSON || function(s) {
-				/* jslint evil:true */
-				return window['eval']('(' + s + ')');			// eslint-disable-line dot-notation
+
+				// Arise an error resolvable including jquery instead of 
+				// making a new function using unsanitized inputs
+
+				window.console.error('jquery.parseJSON is undefined');
+				return null;
 			};
 
 			var httpData = function(xhr, type, s) { // mostly lifted from jq1.4.4


### PR DESCRIPTION
### 📊 Metadata *

_Please enter the direct URL for this bounty on huntr.dev. This is compulsory and will help us process your bounty submission quicker._

#### Bounty URL:  https://www.huntr.dev/bounties/1-npm-form

### ⚙️ Description *

The `form` library suffered of a `XSS` issue, which was caused by 2 minor issues inside the `code`, which made possible the usage of `eval` on `unsanitized values` (inside the "override" of `parseJSON`) and `html parsing` on a `unsanitized AJAX response`.

### 💻 Technical Description *

The 2 issues have been fixed in the following way:

* The `eval` inside the `parseJSON` function has been removed, while it's been added a `error` which arises when the default `$.parseJSON` function (on `jquery`) isn't declared (anyone with good intentions would simply add the `jquery` script on the page and all works correctly again).

* The `unsanitized AJAX response` was previously passed to `parseHTML` without any check, making possible inject additional `HTML`. I used a peculiarity of `jquery` to translate the `HTML` nodes evaluated into `text nodes`, which are equal to `HTML encoded entities` (can be verified seeing this: 
![Screenshot from 2020-07-31 01-23-33](https://user-images.githubusercontent.com/33063403/88983915-8ed97a00-d2cc-11ea-99bd-5d5a7ba0e4c1.png))


### 🐛 Proof of Concept (PoC) *

No PoC was provided, so I worked mostly theoretically on the issue/lines identified by the 2 issues in the `original repo`

### 🔥 Proof of Fix (PoF) *

Theoretical fix :smile: 

### 👍 User Acceptance Testing (UAT)

Can't be sure of this but seems all OK (nodes are still nodes of different type and a function is null --> arises exception due to a function undefined)